### PR TITLE
Header navigation tabs

### DIFF
--- a/portal/src/app/shared/components/global-header/GlobalHeader.module.scss
+++ b/portal/src/app/shared/components/global-header/GlobalHeader.module.scss
@@ -11,7 +11,6 @@ $headerSuperUser: #a4f1c1;
   color: var($primaryWhite);
   display: flex;
   font-size: $headerFontSize;
-  justify-content: space-between;
   line-height: var($headerSize);
   padding-inline-end: var($layoutPadding);
   padding-inline-start: var($layoutPadding);
@@ -21,6 +20,10 @@ $headerSuperUser: #a4f1c1;
 .header_right_block {
   align-items: center;
   display: flex;
+}
+
+.header_left_block {
+  margin-inline-end: 124px;
 }
 
 .home_icon {

--- a/portal/src/app/shared/components/global-header/GlobalHeader.test.tsx
+++ b/portal/src/app/shared/components/global-header/GlobalHeader.test.tsx
@@ -3,11 +3,21 @@ import { MemoryRouter } from 'react-router-dom';
 import { InternalLink } from '../att-link';
 import { GlobalHeader } from './GlobalHeader';
 
+const tabs = [
+  {
+    link: '/',
+    title: 'Home',
+  },
+  {
+    link: '/all-experiments',
+    title: 'All Experiments',
+  }
+];
 jest.mock('../att-link');
 describe('GlobalHeader', () => {
   test('renders global header ', () => {
     (InternalLink as jest.Mock).mockImplementation(() => <div>InternalLink</div>);
-    const { container }: RenderResult = render(<GlobalHeader title='react' />, { wrapper: MemoryRouter });
+    const { container }: RenderResult = render(<GlobalHeader tabs={tabs} />, { wrapper: MemoryRouter });
     expect(container.firstChild).toMatchSnapshot();
   });
 });

--- a/portal/src/app/shared/components/global-header/GlobalHeader.tsx
+++ b/portal/src/app/shared/components/global-header/GlobalHeader.tsx
@@ -4,14 +4,12 @@ import { NAVIGATION_ROUTES } from '../../../routes-navigation.const';
 import { InternalLink, LinkStyle, LinkSize } from '../att-link';
 import styles from './GlobalHeader.module.scss';
 import QujataLogoSvg from '../../../../assets/images/qujata-logo.svg';
-import AvatarSvg from "../../../../assets/images/user-avatar.svg";
+import { NavigationTab, INavigationTab } from '../navigation-tab';
 
 export interface GlobalHeaderProps {
-  title: string;
+  tabs: INavigationTab[];
   className?: string
-
 }
-
 export const GlobalHeader: React.FC<PropsWithChildren<GlobalHeaderProps>> = (props: PropsWithChildren<GlobalHeaderProps>) => (
   <header className={cn(props.className, styles.global_header)}>
     <div className={styles.header_left_block}>
@@ -24,8 +22,6 @@ export const GlobalHeader: React.FC<PropsWithChildren<GlobalHeaderProps>> = (pro
         <img className={styles.home_icon} src={QujataLogoSvg} alt="globe" />
       </InternalLink>
     </div>
-    {/* <div className={styles.header_right_block}>
-      <img className={styles.avatar_style} src={AvatarSvg} alt="avatar" />
-    </div> */}
+    <NavigationTab tabs={props.tabs} />
   </header>
 );

--- a/portal/src/app/shared/components/global-header/GlobalHeader.tsx
+++ b/portal/src/app/shared/components/global-header/GlobalHeader.tsx
@@ -4,7 +4,7 @@ import { NAVIGATION_ROUTES } from '../../../routes-navigation.const';
 import { InternalLink, LinkStyle, LinkSize } from '../att-link';
 import styles from './GlobalHeader.module.scss';
 import QujataLogoSvg from '../../../../assets/images/qujata-logo.svg';
-import { NavigationTab, INavigationTab } from '../navigation-tab';
+import { INavigationTab, NavigationTab } from '../navigation-tab/NavigationTab';
 
 export interface GlobalHeaderProps {
   tabs: INavigationTab[];

--- a/portal/src/app/shared/components/global-header/__snapshots__/GlobalHeader.test.tsx.snap
+++ b/portal/src/app/shared/components/global-header/__snapshots__/GlobalHeader.test.tsx.snap
@@ -11,5 +11,26 @@ exports[`GlobalHeader renders global header  1`] = `
       InternalLink
     </div>
   </div>
+  <div
+    class="tabs"
+  >
+    <div>
+      <a
+        aria-current="page"
+        class="tab activeTab active"
+        href="/"
+      >
+        Home
+      </a>
+    </div>
+    <div>
+      <a
+        class="tab"
+        href="/all-experiments"
+      >
+        All Experiments
+      </a>
+    </div>
+  </div>
 </header>
 `;

--- a/portal/src/app/shared/components/navigation-tab/NavigationTab.module.scss
+++ b/portal/src/app/shared/components/navigation-tab/NavigationTab.module.scss
@@ -1,0 +1,18 @@
+@import "src/styles/variables-keys";
+
+.tabs {
+    display: flex;
+    align-items: center;
+}
+
+.tab {
+    color: var($primaryWhite);
+    margin-inline-end: 20px;
+    text-decoration: none;
+}
+
+.activeTab {
+    text-decoration: underline;
+    text-underline-offset: 5px;
+    text-decoration-thickness: 2px;
+}

--- a/portal/src/app/shared/components/navigation-tab/NavigationTab.module.scss
+++ b/portal/src/app/shared/components/navigation-tab/NavigationTab.module.scss
@@ -16,3 +16,8 @@
     text-underline-offset: 5px;
     text-decoration-thickness: 2px;
 }
+
+.disabledTab {
+    cursor: not-allowed;
+    opacity: 0.5;
+}

--- a/portal/src/app/shared/components/navigation-tab/NavigationTab.test.tsx
+++ b/portal/src/app/shared/components/navigation-tab/NavigationTab.test.tsx
@@ -1,0 +1,20 @@
+import { render, RenderResult } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { NavigationTab } from './NavigationTab';
+
+const tabs = [
+  {
+    link: '/',
+    title: 'Home',
+  },
+  {
+    link: '/all-experiments',
+    title: 'All Experiments',
+  }
+];
+describe('NavigationTab', () => {
+  test('renders Navigation Tab', () => {
+    const { container }: RenderResult = render(<NavigationTab tabs={tabs} />, { wrapper: MemoryRouter });
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/portal/src/app/shared/components/navigation-tab/NavigationTab.tsx
+++ b/portal/src/app/shared/components/navigation-tab/NavigationTab.tsx
@@ -1,0 +1,31 @@
+import { NavLink, useLocation } from 'react-router-dom';
+import styles from './NavigationTab.module.scss';
+import cn from 'classnames';
+
+export interface INavigationTab {
+  title: string;
+  link: string;
+}
+export interface NavigationTabProps {
+  tabs: INavigationTab[];
+}
+
+export const NavigationTab: React.FC<NavigationTabProps> = (props: NavigationTabProps) => {
+    const { tabs } = props;
+    const location = useLocation();
+
+    return (
+        <div className={styles.tabs}>
+           {tabs.map(((tab: INavigationTab, index: number) => (
+            <div key={index}>
+                <NavLink 
+                    className={cn(styles.tab, {[styles.activeTab]: location.pathname === tab.link})} 
+                    to={tab.link}             
+                >
+                    {tab.title}
+                </NavLink>
+            </div>
+          )))}
+        </div>
+    );
+}

--- a/portal/src/app/shared/components/navigation-tab/NavigationTab.tsx
+++ b/portal/src/app/shared/components/navigation-tab/NavigationTab.tsx
@@ -5,6 +5,7 @@ import cn from 'classnames';
 export interface INavigationTab {
   title: string;
   link: string;
+  disabled?: boolean;
 }
 export interface NavigationTabProps {
   tabs: INavigationTab[];
@@ -19,7 +20,7 @@ export const NavigationTab: React.FC<NavigationTabProps> = (props: NavigationTab
            {tabs.map(((tab: INavigationTab, index: number) => (
             <div key={index}>
                 <NavLink 
-                    className={cn(styles.tab, {[styles.activeTab]: location.pathname === tab.link})} 
+                    className={cn(styles.tab, {[styles.activeTab]: location.pathname === tab.link}, {[styles.disabledTab]: tab.disabled})} 
                     to={tab.link}             
                 >
                     {tab.title}

--- a/portal/src/app/shared/components/navigation-tab/__snapshots__/NavigationTab.test.tsx.snap
+++ b/portal/src/app/shared/components/navigation-tab/__snapshots__/NavigationTab.test.tsx.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NavigationTab renders Navigation Tab 1`] = `
+<div
+  class="tabs"
+>
+  <div>
+    <a
+      aria-current="page"
+      class="tab activeTab active"
+      href="/"
+    >
+      Home
+    </a>
+  </div>
+  <div>
+    <a
+      class="tab"
+      href="/all-experiments"
+    >
+      All Experiments
+    </a>
+  </div>
+</div>
+`;

--- a/portal/src/app/shared/components/navigation-tab/index.ts
+++ b/portal/src/app/shared/components/navigation-tab/index.ts
@@ -1,0 +1,1 @@
+export * from './NavigationTab';

--- a/portal/src/app/shared/constants/navigation-tabs.const.ts
+++ b/portal/src/app/shared/constants/navigation-tabs.const.ts
@@ -8,5 +8,6 @@ export const tabs = [
     {
       link: '/all-experiments',
       title: SHARED_EN.NAVIGATION_TABS.ALL_EXPERIMENTS,
+      disabled: true,
     }
 ];

--- a/portal/src/app/shared/constants/navigation-tabs.const.ts
+++ b/portal/src/app/shared/constants/navigation-tabs.const.ts
@@ -1,0 +1,12 @@
+import { SHARED_EN } from '../../../../src/app/shared/translate/en';
+
+export const tabs = [
+    {
+      link: '/',
+      title: SHARED_EN.NAVIGATION_TABS.HOME,
+    },
+    {
+      link: '/all-experiments',
+      title: SHARED_EN.NAVIGATION_TABS.ALL_EXPERIMENTS,
+    }
+];

--- a/portal/src/app/shared/translate/en.ts
+++ b/portal/src/app/shared/translate/en.ts
@@ -6,4 +6,8 @@ export const SHARED_EN = {
   TOAST_DESCRIPTIONS: {
     SUCCESS: 'Success',
   },
+  NAVIGATION_TABS: {
+    HOME: 'Home',
+    ALL_EXPERIMENTS: 'All Experiments',
+  }
 };

--- a/portal/src/routes/Root.jsx
+++ b/portal/src/routes/Root.jsx
@@ -1,11 +1,11 @@
 import { GlobalHeader } from '../app/shared/components/global-header/index';
-import { SHARED_EN } from '../../src/app/shared/translate/en';
 import { Outlet } from 'react-router-dom';
+import { tabs } from '../app/shared/constants/navigation-tabs.const';
 
 export default function Root() {
   return (
     <>
-      <GlobalHeader title={SHARED_EN.WEB_PORTAL_NAME} />
+      <GlobalHeader tabs={tabs} />
       <Outlet />
     </>
   );

--- a/portal/src/routes/index.jsx
+++ b/portal/src/routes/index.jsx
@@ -2,6 +2,7 @@ import { createBrowserRouter } from 'react-router-dom';
 import Root from './Root';
 import { Home } from '../app/components/home/Home';
 
+const isAllExperimentTabEnabled = false;
 export const router = createBrowserRouter([
     {
         path: '/',
@@ -17,10 +18,10 @@ export const router = createBrowserRouter([
                 },
             ],
           },
-          {
+          ...(isAllExperimentTabEnabled ? [{
             path: 'All-Experiments',
             element: <div>All Experiments</div>,
-          },
+          }] : []),
         ],
     },
 ]);

--- a/portal/src/routes/index.jsx
+++ b/portal/src/routes/index.jsx
@@ -8,12 +8,14 @@ export const router = createBrowserRouter([
         element: <Root />,
         children: [
           {
-            index: true,
+            path: '/',
             element: <Home />,
-          },
-          {
-            path: 'ExperimentName',
-            element: <div>Experiment Name</div>,
+            children: [
+                {
+                    path: 'ExperimentName',
+                    element: <div>Experiment Name</div>,
+                },
+            ],
           },
           {
             path: 'All-Experiments',

--- a/portal/src/routes/index.jsx
+++ b/portal/src/routes/index.jsx
@@ -13,7 +13,7 @@ export const router = createBrowserRouter([
             element: <Home />,
             children: [
                 {
-                    path: 'ExperimentName',
+                    path: '',
                     element: <div>Experiment Name</div>,
                 },
             ],


### PR DESCRIPTION
- create new component for `NavigationTab`
- add `NavigationTab` to the header 
- disabled `all-experiments` tab

![F868DABE-DA90-4523-B08D-396AA2FC0E49_4_5005_c](https://github.com/att/qujata/assets/144895570/2bd70e28-1ae0-40ef-bd44-6b5bdad16988)
